### PR TITLE
[Phototherapy] Usage terms dialog

### DIFF
--- a/phototherapy/css/phototherapy.css
+++ b/phototherapy/css/phototherapy.css
@@ -94,4 +94,23 @@ html, body {
     margin-left: 10px;
   }
 
+.usage-terms-dialog-backdrop {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 100;
+  left: 0;
+  top: 0;
+  background-color: rgba(0,0,0,0.4);
+  overflow: auto;
+}
 
+.usage-terms-dialog {
+  width: 80%;
+  max-width: 600px;
+  margin: 10% auto;
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 0 10px -1px rgba(0,0,0,0.2);
+}

--- a/phototherapy/css/phototherapy.css
+++ b/phototherapy/css/phototherapy.css
@@ -101,7 +101,7 @@ html, body {
   z-index: 100;
   left: 0;
   top: 0;
-  background-color: rgba(0,0,0,0.4);
+  background-color: rgba(0, 0, 0, 0.4);
   overflow: auto;
 }
 
@@ -112,5 +112,10 @@ html, body {
   background-color: white;
   padding: 20px;
   border-radius: 10px;
-  box-shadow: 0 0 10px -1px rgba(0,0,0,0.2);
+  box-shadow: 0 0 10px -1px rgba(0, 0, 0, 0.2);
+}
+
+.usage-terms-dialog-action {
+  display: block;
+  margin: 0 auto;
 }

--- a/phototherapy/index.html
+++ b/phototherapy/index.html
@@ -56,7 +56,7 @@
       <p>
         בשימושך באתר אתה מצהיר כי הנך חבר צוות רפואי בבית החולים אסותא אשדוד, והנך מבין כי האתר מיועד לשימוש תומך החלטה בלבד ואינו מהווה תחליף לשיקול דעת הרופא המטפל. לחץ על "אני מסכים" על מנת להמשיך.
       </p>
-      <button type="button" class="btn btn-outline-secondary buttons-color" ng-click="ctrl.acceptTerms()">אני מסכים</button>
+      <button type="button" class="btn btn-outline-secondary buttons-color usage-terms-dialog-action" ng-click="ctrl.acceptTerms()">אני מסכים</button>
     </div>
   </div>
 <div id="calculator" style="overflow-y: auto;overflow-x: hidden; padding-bottom: 10px;" ng-show="ctrl.dataShown=='CALCULATOR'" >

--- a/phototherapy/index.html
+++ b/phototherapy/index.html
@@ -51,6 +51,14 @@
   </div>
 </nav>
 <div id="phototherapy-main" class="container main-content phototherapy-main-content">  
+  <div id="usage-terms-dialog-backdrop" class="usage-terms-dialog-backdrop" ng-show="!ctrl.termsSigned">
+    <div id="usage-terms-dialog" class="usage-terms-dialog">
+      <p>
+        משלום מאפשר לך להשתמש במחשבון זה ללא תשלום. המחשבון מיועד לשימוש תומך בלבד ואינו מהווה תחליף לשיקול דעת רפואי מקצועי. על מנת להשתמש במחשבון זה עליך להסכים לתנאי השימוש. לחץ על "אני מסכים" על מנת להמשיך.
+      </p>
+      <button type="button" class="btn btn-primary" ng-click="ctrl.acceptTerms()">אני מסכים</button>
+    </div>
+  </div>
 <div id="calculator" style="overflow-y: auto;overflow-x: hidden; padding-bottom: 10px;" ng-show="ctrl.dataShown=='CALCULATOR'" >
   <div class="group-container">
     <form>

--- a/phototherapy/index.html
+++ b/phototherapy/index.html
@@ -54,7 +54,7 @@
   <div id="usage-terms-dialog-backdrop" class="usage-terms-dialog-backdrop" ng-show="!ctrl.termsSigned">
     <div id="usage-terms-dialog" class="usage-terms-dialog">
       <p>
-        משלום מאפשר לך להשתמש במחשבון זה ללא תשלום. המחשבון מיועד לשימוש תומך בלבד ואינו מהווה תחליף לשיקול דעת רפואי מקצועי. על מנת להשתמש במחשבון זה עליך להסכים לתנאי השימוש. לחץ על "אני מסכים" על מנת להמשיך.
+        בשימושך באתר אתה מצהיר כי הנך חבר צוות רפואי באסותא אשדוד, והנך מבין כי האתר מיועד לשימוש תומך בלבד ואינו מהווה תחליף לשיקול דעת רפואי מקצועי. לחץ על "אני מסכים" על מנת להמשיך.
       </p>
       <button type="button" class="btn btn-primary" ng-click="ctrl.acceptTerms()">אני מסכים</button>
     </div>

--- a/phototherapy/index.html
+++ b/phototherapy/index.html
@@ -56,7 +56,7 @@
       <p>
         בשימושך באתר אתה מצהיר כי הנך חבר צוות רפואי בבית החולים אסותא אשדוד, והנך מבין כי האתר מיועד לשימוש תומך החלטה בלבד ואינו מהווה תחליף לשיקול דעת הרופא המטפל. לחץ על "אני מסכים" על מנת להמשיך.
       </p>
-      <button type="button" class="btn btn-primary" ng-click="ctrl.acceptTerms()">אני מסכים</button>
+      <button type="button" class="btn btn-outline-secondary buttons-color" ng-click="ctrl.acceptTerms()">אני מסכים</button>
     </div>
   </div>
 <div id="calculator" style="overflow-y: auto;overflow-x: hidden; padding-bottom: 10px;" ng-show="ctrl.dataShown=='CALCULATOR'" >

--- a/phototherapy/index.html
+++ b/phototherapy/index.html
@@ -54,7 +54,7 @@
   <div id="usage-terms-dialog-backdrop" class="usage-terms-dialog-backdrop" ng-show="!ctrl.termsSigned">
     <div id="usage-terms-dialog" class="usage-terms-dialog">
       <p>
-        בשימושך באתר אתה מצהיר כי הנך חבר צוות רפואי באסותא אשדוד, והנך מבין כי האתר מיועד לשימוש תומך בלבד ואינו מהווה תחליף לשיקול דעת רפואי מקצועי. לחץ על "אני מסכים" על מנת להמשיך.
+        בשימושך באתר אתה מצהיר כי הנך חבר צוות רפואי בבית החולים אסותא אשדוד, והנך מבין כי האתר מיועד לשימוש תומך החלטה בלבד ואינו מהווה תחליף לשיקול דעת הרופא המטפל. לחץ על "אני מסכים" על מנת להמשיך.
       </p>
       <button type="button" class="btn btn-primary" ng-click="ctrl.acceptTerms()">אני מסכים</button>
     </div>

--- a/phototherapy/js/phototherapy.js
+++ b/phototherapy/js/phototherapy.js
@@ -22,7 +22,8 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
     var phototherapyCtx = document.getElementById('phototherapyChart').getContext('2d');
 
     const termsSignedKey = 'mashlom.termsSigned';
-    ctrl.termsSigned = localStorage.getItem(termsSignedKey) === 'true';
+    const termsVersion = '20240714.1';
+    ctrl.termsSigned = localStorage.getItem(termsSignedKey) === termsVersion;
 
     ctrl.clearContent = function(attr) {
         ctrl[attr]  = null;
@@ -159,7 +160,7 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
 
     ctrl.acceptTerms = function() {
         ctrl.termsSigned = true;
-        localStorage.setItem(termsSignedKey, 'true');
+        localStorage.setItem(termsSignedKey, termsVersion);
     };
 }]);
 

--- a/phototherapy/js/phototherapy.js
+++ b/phototherapy/js/phototherapy.js
@@ -22,8 +22,8 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
     var phototherapyCtx = document.getElementById('phototherapyChart').getContext('2d');
 
     const termsSignedKey = 'mashlom.termsSigned';
-    const termsVersion = '20240714.1';
-    ctrl.termsSigned = localStorage.getItem(termsSignedKey) === termsVersion;
+    const termsVersion = Date.parse('2024-07-14');
+    ctrl.termsSigned = localStorage.getItem(termsSignedKey) >= termsVersion;
 
     ctrl.clearContent = function(attr) {
         ctrl[attr]  = null;
@@ -160,7 +160,7 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
 
     ctrl.acceptTerms = function() {
         ctrl.termsSigned = true;
-        localStorage.setItem(termsSignedKey, termsVersion);
+        localStorage.setItem(termsSignedKey, Date.now());
     };
 }]);
 

--- a/phototherapy/js/phototherapy.js
+++ b/phototherapy/js/phototherapy.js
@@ -160,7 +160,7 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
     ctrl.acceptTerms = function() {
         ctrl.termsSigned = true;
         localStorage.setItem(termsSignedKey, 'true');
-    }
+    };
 }]);
 
 app.directive('selectOnClick', ['$window', function ($window) {

--- a/phototherapy/js/phototherapy.js
+++ b/phototherapy/js/phototherapy.js
@@ -21,6 +21,9 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
     var butaniCtx = document.getElementById('butaniChart').getContext('2d');
     var phototherapyCtx = document.getElementById('phototherapyChart').getContext('2d');
 
+    const termsSignedKey = 'mashlom.termsSigned';
+    ctrl.termsSigned = localStorage.getItem(termsSignedKey) === 'true';
+
     ctrl.clearContent = function(attr) {
         ctrl[attr]  = null;
     }
@@ -154,6 +157,10 @@ app.controller("PhototherapyController", ['$scope', '$rootScope', '$timeout', fu
         }
     }
 
+    ctrl.acceptTerms = function() {
+        ctrl.termsSigned = true;
+        localStorage.setItem(termsSignedKey, 'true');
+    }
 }]);
 
 app.directive('selectOnClick', ['$window', function ($window) {


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `phototherapy` application: a usage terms acceptance dialog. This dialog is displayed to the user until they accept the terms of usage. The most significant changes include the addition of new CSS classes for the dialog and its backdrop, the addition of the dialog in the HTML structure, and the implementation of the dialog's behavior in the JavaScript controller.

## User Interface changes

* [`phototherapy/css/phototherapy.css`](diffhunk://#diff-9679d5378d402bd96e3db2f1f3f24d8c7513b4568a443a0d3d3e384a9cedec1dL97-R116): Added new CSS classes `.usage-terms-dialog-backdrop` and `.usage-terms-dialog` to style the usage terms acceptance dialog and its backdrop. These classes set the dimensions, positioning, and appearance of the dialog and its backdrop.

* [`phototherapy/index.html`](diffhunk://#diff-cf9e6f23210dfe9bc4989ddaf8038ceed20da756c7af7fda35a09cfa6ab0ded5R54-R61): Inserted the usage terms acceptance dialog into the HTML structure. The dialog contains a paragraph of text and a button for accepting the terms. It is displayed when the `ctrl.termsSigned` value is false.

## Behavioral changes

* [`phototherapy/js/phototherapy.js`](diffhunk://#diff-85423115cb0ae090ccbebb1f1cd982f6d77990d3204221be2d75213c2eb1ec4cR24-R26): Introduced a new `termsSignedKey` constant and a new `ctrl.termsSigned` property to track whether the user has accepted the terms or not. This value is stored in the local storage. A new `ctrl.acceptTerms` method was also added to handle the acceptance of the terms. [[1]](diffhunk://#diff-85423115cb0ae090ccbebb1f1cd982f6d77990d3204221be2d75213c2eb1ec4cR24-R26) [[2]](diffhunk://#diff-85423115cb0ae090ccbebb1f1cd982f6d77990d3204221be2d75213c2eb1ec4cR160-R163)

## Screens

![image](https://github.com/user-attachments/assets/f41be3f8-d938-473d-ba45-d4c1a19f7cf6)

